### PR TITLE
Check for reproducibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,17 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
 
-      - name: Build the tiniktls-docker images
+      - name: Build the tiniktls-builder Docker image
         uses: docker/build-push-action@v6
         with:
           context: docker
           file: docker/Dockerfile.builder
           tags: tiniktls-builder:latest
 
-      - name: Build the tiniktls-qa images
+      - name: Build tiniktls
+        run: docker run --rm -v "$PWD:/tiniktls" tiniktls-builder
+
+      - name: Build the tiniktls-qa Docker image
         uses: docker/build-push-action@v6
         with:
           context: docker

--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ You can build it with docker:
 docker build -t tiniktls-builder -f docker/Dockerfile.builder docker
 ```
 
-Run the `tiniktls-builder` to produce the `tiniktls-static` binary:
+During development build `tiniktls` and update `SHA256SUMS` with:
+
+```shell
+docker run --rm -it -v "$PWD:/tiniktls" -e SHA256SUMS=update tiniktls-builder
+```
+
+If you want to build `tiniktls` and check that it matches the hash in `SHA256SUMS`:
 
 ```shell
 docker run --rm -it -v "$PWD:/tiniktls" tiniktls-builder

--- a/SHA256SUMS
+++ b/SHA256SUMS
@@ -1,0 +1,1 @@
+73a79cc6cb47da1903423c8c32dc51eeb51c0022878ef9711ba84fd72a391fb8  build/tiniktls

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -3,7 +3,8 @@ FROM alpine:3.21
 RUN apk --no-cache add musl-dev gcc make perl linux-headers cmake curl
 
 COPY musl.cmake /opt/musl.cmake
-ENV CMAKE_TOOLCHAIN_FILE=/opt/musl.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/opt/musl.cmake \
+    SOURCE_DATE_EPOCH=0
 
 # download and build openssl
 WORKDIR /opt/openssl
@@ -13,7 +14,7 @@ RUN curl -fsL --tlsv1.3 https://github.com/openssl/openssl/archive/refs/tags/ope
     rm openssl.tgz
 
 # NOTE: no-asm makes it a lot smaller but also a lot slower (no free lunch)
-RUN ./Configure enable-ktls no-docs no-tests no-shared no-afalgeng no-async no-capieng no-cmp no-cms \
+RUN ./Configure enable-ktls no-apps no-docs no-tests no-shared no-afalgeng no-async no-capieng no-cmp no-cms \
     no-comp no-ct no-dgram no-dso no-dynamic-engine no-engine no-filenames no-gost no-http no-legacy \
     no-module no-nextprotoneg no-ocsp no-padlockeng no-quic no-srp no-srtp no-ssl-trace no-thread-pool \
     no-ts no-ui-console no-uplink no-ssl3-method no-tls1-method no-tls1_1-method no-dtls1-method \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 owner=$(stat -c '%u:%g' .)
 trap 'chown -R ${owner:?} build' EXIT
@@ -8,3 +8,9 @@ trap 'chown -R ${owner:?} build' EXIT
 rm -rf build 
 cmake -B build
 cmake --build build
+
+if [ "$SHA256SUMS" = update ]; then
+    sha256sum build/tiniktls >SHA256SUMS
+else
+    sha256sum -c SHA256SUMS
+fi

--- a/docker/qa.sh
+++ b/docker/qa.sh
@@ -2,11 +2,10 @@
 
 set -ex
 
+test -e build/tiniktls
+
 owner=$(stat -c '%u:%g' .)
 trap 'chown -R ${owner:?} src' EXIT
-
-echo "=== Building ==="
-/opt/build.sh
 
 echo "=== Testing ==="
 TINIKTLS_CA_CHAIN=test/certs/ca-chain.pem build/tiniktls -- python3 test/ktls_tests.py


### PR DESCRIPTION
tiniktls-builder should always build the same tiniktls binary. Added check in build.sh to confirm this.

When changing the source build.sh needs to be updated accordingly.